### PR TITLE
doc: add feature info to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ sonic-channel = { version = "0.2" }
 
 ### Search channel
 
+Note: This example requires enabling the `search` feature, enabled by default.
+
 ```rust
 use sonic_channel::*;
 
@@ -44,6 +46,8 @@ fn main() -> result::Result<()> {
 ```
 
 ### Ingest channel
+
+Note: This example requires enabling the `ingest` feature.
 
 ```rust
 use sonic_channel::*;

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -7,7 +7,6 @@ use std::net::{TcpStream, ToSocketAddrs};
 const DEFAULT_SONIC_PROTOCOL_VERSION: usize = 1;
 const MAX_LINE_BUFFER_SIZE: usize = 20000;
 const UNINITIALIZED_MODE_MAX_BUFFER_SIZE: usize = 200;
-const BUFFER_LINE_SEPARATOR: u8 = '\n' as u8;
 
 macro_rules! init_commands {
     (
@@ -54,15 +53,28 @@ macro_rules! init_commands {
 /// Channel modes supported by sonic search backend.
 #[derive(Debug, Clone, Copy)]
 pub enum ChannelMode {
-    /// Search mode
+    /// Sonic server search channel mode.
+    /// 
+    /// In this mode you can use `query`, `suggest`, `ping` and `quit` commands.
+    /// 
+    /// Note: This mode requires enabling the `search` feature.
     #[cfg(feature = "search")]
     Search,
 
-    /// Ingest mode
+    /// Sonic server ingest channel mode.
+    /// 
+    /// In this mode you can use `push`, `pop`, `flushc`, `flushb`, `flusho`, 
+    /// `ping` and `quit` commands.
+    /// 
+    /// Note: This mode requires enabling the `ingest` feature.
     #[cfg(feature = "ingest")]
     Ingest,
 
-    /// Control mode
+    /// Sonic server control channel mode.
+    /// 
+    /// In this mode you can use `ping` and `quit` commands.
+    /// 
+    /// Note: This mode requires enabling the `control` feature.
     #[cfg(feature = "control")]
     Control,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,8 @@
 //! ## Example usage
 //! 
 //! ### Search channel
+//!
+//! Note: This example requires enabling the `search` feature, enabled by default.
 //! 
 //! ```rust
 //! use sonic_channel::*;
@@ -25,6 +27,8 @@
 //! 
 //! ### Ingest channel
 //! 
+//! Note: This example requires enabling the `ingest` feature.
+//!
 //! ```rust
 //! use sonic_channel::*;
 //! 


### PR DESCRIPTION
Closes #1

I've added information to documentation and readme about features to examples and channel mode